### PR TITLE
Added support for excluding files

### DIFF
--- a/pydirl/cli.py
+++ b/pydirl/cli.py
@@ -7,10 +7,11 @@ from .app import main
 @click.argument('root', type=click.Path(), metavar='[PATH]', default='./', required=False)
 @click.option('-p', '--port', type=click.IntRange(min=1, max=65535), metavar="<port>", help='listening port')
 @click.option('-a', '--address', type=click.STRING, metavar="<address>", help='address to bind')
+@click.option('--exclude', type=click.STRING, metavar="<regex>", help='regex to exclude matching files and directories')
 @click.option('-d', '--debug', is_flag=True, help='debug mode')
 @click.option('--folder-size', is_flag=True, help='calculate size also for folders (WARNING: could become really slow)')
 @click.option('--last-modified', is_flag=True, help='display last modified time')
-def pydirl(root, port, address, debug, folder_size, last_modified):
+def pydirl(root, port, address, exclude, debug, folder_size, last_modified):
     conf = {'ROOT': root,
             'DEBUG': debug,
             'FOLDER_SIZE': folder_size,
@@ -19,6 +20,8 @@ def pydirl(root, port, address, debug, folder_size, last_modified):
         conf['PORT'] = port
     if address:
         conf['ADDRESS'] = address
+    if exclude:
+        conf['EXCLUDE'] = exclude
 
     try:
         main(conf)

--- a/test/test_exclude.py
+++ b/test/test_exclude.py
@@ -1,0 +1,47 @@
+import unittest
+import shutil
+import tempfile
+from pydirl.app import create_app
+from . import populate_directory
+
+
+class PydirlExcludeTestCase(unittest.TestCase):
+
+    def setUp(self):
+        self.root = tempfile.mkdtemp(prefix='pydirl_test_')
+        populate_directory(self.root)
+
+    def tearDown(self):
+        shutil.rmtree(self.root)
+
+    def create_app_with_regex(self, regex):
+        self.app = create_app({'ROOT': self.root, 'EXCLUDE': regex})
+        self.app = self.app.test_client()
+
+    def test_exclude_all(self):
+        self.create_app_with_regex(r'.*')
+        rsp = self.app.get('/1/1-1/1-1.txt')
+        self.assertEqual(rsp.status_code, 404)
+        rsp = self.app.get('/1/1-1')
+        self.assertEqual(rsp.status_code, 404)
+        rsp = self.app.get('/2/')
+        self.assertEqual(rsp.status_code, 404)
+        rsp = self.app.get('/empty/')
+        self.assertEqual(rsp.status_code, 404)
+
+    def test_exclude_file(self):
+        self.create_app_with_regex(r'.*1-1.txt')
+        rsp = self.app.get('/1/1-1/1-1.txt')
+        self.assertEqual(rsp.status_code, 404)
+
+    def test_exclude_file_and_directory(self):
+        self.create_app_with_regex(r'.*1-1')
+        rsp = self.app.get('/1/1-1')
+        self.assertEqual(rsp.status_code, 404)
+        rsp = self.app.get('/1/1-1/1-1.txt')
+        self.assertEqual(rsp.status_code, 404)
+
+    def test_exclude_directory(self):
+        self.create_app_with_regex(r'.*1-1/')
+        rsp = self.app.get('/1/1-1/')
+        self.assertEqual(rsp.status_code, 404)


### PR DESCRIPTION
I added a new command line argument `--exclude` that takes a python regex and use it to filter out matching files. 

Matching is done only considering the relative portion of a file path with respect to the root path served by the script.

If someone tries to request a file that was excluded, the server responses with a `404` error.