### PR TITLE
Single file mode simpler

### DIFF
--- a/pydirl/app.py
+++ b/pydirl/app.py
@@ -48,14 +48,21 @@ def create_app(conf={}):
 
     @app.route('/', defaults={'relPath': ''})
     @app.route('/<path:relPath>')
-    def folder_route(relPath):
-
+    def general_route(relPath):
         path = safe_join(app.root, relPath)
         app.logger.debug("Absolute requested path: '{0}'".format(path))
 
         if app.exclude and app.exclude.match(relPath):
             app.logger.debug("Requested path matches exclude expression")
             abort(404)
+
+        # check for single-file-mode
+        if os.path.isfile(app.root):
+            app.logger.debug('Single file mode triggered')
+            singleFileName = os.path.basename(app.root)
+            if relPath != singleFileName:
+                return redirect(singleFileName, code=302)
+            return send_file(app.root)
 
         if os.path.isfile(path):
             return send_file(path)

--- a/pydirl/cli.py
+++ b/pydirl/cli.py
@@ -12,6 +12,18 @@ from .app import main
 @click.option('--folder-size', is_flag=True, help='calculate size also for folders (WARNING: could become really slow)')
 @click.option('--last-modified', is_flag=True, help='display last modified time')
 def pydirl(root, port, address, exclude, debug, folder_size, last_modified):
+    '''Quick file sharing solution
+
+       Start a simple web server to share files and folders over HTTP protocol.
+
+      \b
+       PATH controls which elements will be shared:
+        - if PATH is a directory, all elements under it will be shared.
+        - if PATH is a file, single-file mode will be triggered and
+          only that file will be shared.
+        - if PATH is not given the current directory (PWD) will be used.
+    '''
+
     conf = {'ROOT': root,
             'DEBUG': debug,
             'FOLDER_SIZE': folder_size,

--- a/test/test_single_file_mode.py
+++ b/test/test_single_file_mode.py
@@ -1,0 +1,28 @@
+import unittest
+import shutil
+import tempfile
+import os
+from pydirl.app import create_app
+from . import populate_directory
+
+
+class PydirlSingleTestCase(unittest.TestCase):
+
+    def setUp(self):
+        self.tmpFolder = tempfile.mkdtemp(prefix='pydirl_test_')
+        populate_directory(self.tmpFolder)
+        self.root = os.path.join(self.tmpFolder, '1/1-1/1-1.txt')
+        app = create_app({'DEBUG': True, 'ROOT': self.root})
+        self.app = app.test_client()
+
+    def tearDown(self):
+        shutil.rmtree(self.tmpFolder)
+
+    def test_redirect(self):
+        rsp = self.app.get('/in/the/middle/of/nowhere')
+        self.assertEqual(rsp.status_code, 302)
+
+    def test_download(self):
+        rsp = self.app.get(os.path.basename(self.root))
+        self.assertEqual(rsp.status_code, 200)
+        self.assertEqual(rsp.data, b'standard-content 1-1')


### PR DESCRIPTION
If the given root path points to an existing file, the single-file-mode is
triggered:

 - For any uri different from the single-file name an 302 redirect will
   be issue to the single-file uri.
 - If the uri is equal to the single-file name, the single-file will be
   served.